### PR TITLE
Fix password to follow login best practice

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,7 @@ pipeline {
             steps{
                 withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId:'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD']]) {
                 sh '''
-                docker login -u $USERNAME -p $PASSWORD
+                echo $PASSWORD | docker login -u $USERNAME --password-stdin
                 docker push $CONTAINER_REPO:$CONTAINER_TAG
                 '''
                 }


### PR DESCRIPTION
The password should be sent via STDIN in a CI/CD pipeline to prevent it to be displayed in CI/CD logs.
docker login best practice : https://docs.docker.com/engine/reference/commandline/login/#provide-a-password-using-stdin 